### PR TITLE
Fix worker break issue

### DIFF
--- a/servers/simple/server.py
+++ b/servers/simple/server.py
@@ -82,7 +82,7 @@ class HttpUriRecognitionServicer(ai_http_uri_recognition_pb2_grpc.HttpUriRecogni
             # It should not be called
             return Empty()
 
-        uris = [str(uri.name) for uri in request.unrecognizedUris]
+        uris = [str(uri.name) for uri in request.unrecognizedUris if uri and uri.name]
         service = str(request.service)
 
         # This is an experimental mechanism to avoid identifying non-restful uris unnecessarily.

--- a/servers/simple/worker.py
+++ b/servers/simple/worker.py
@@ -52,5 +52,7 @@ def run_worker(uri_main_queue, shared_results_object):
             # increment here
             counter += 1
             print('-================-')
+        except Exception as e:
+            print(f"catch an unexpected error occurred: {e}")
         except queue.Empty:  # TODO Consider queue full
             pass


### PR DESCRIPTION
If the OAP sends the empty URI, the worker will break the thread and stop running.
So in this PR, I would exclude the empty URI when receiving an OAP feed data request, and add an exception check for in case the worker breaks down. 