### PR TITLE
Introduce textblob framework to analysis word

### DIFF
--- a/models/uri_drain/template_miner.py
+++ b/models/uri_drain/template_miner.py
@@ -114,6 +114,12 @@ class TemplateMiner:
 
         loaded_drain: Drain = jsonpickle.loads(state, keys=True)
 
+        # load all words into clusters
+        if len(loaded_drain.id_to_cluster) > 0:
+            for _, cluster in loaded_drain.id_to_cluster.items():
+                if isinstance(cluster, LogCluster):
+                    cluster.token_words_check()
+
         # json-pickle encoded keys as string by default, so we have to convert those back to int
         # this is only relevant for backwards compatibility when loading a snapshot of drain <= v0.9.1
         # which did not use json-pickle's keys=true
@@ -137,8 +143,8 @@ class TemplateMiner:
             state = base64.b64encode(zlib.compress(state))
 
         logger.info(f"Saving state of {len(self.drain.clusters)} clusters "
-                    f"with {self.drain.get_total_cluster_size()} messages, {len(state)} bytes, "
-                    f"reason: {snapshot_reason}")
+                    f"with {self.drain.get_total_cluster_size()} messages to service <{self.persistence_handler.get_service()}>, "
+                    f"{len(state)} bytes, reason: {snapshot_reason}")
         self.persistence_handler.save_state(state)
 
     def get_snapshot_reason(self, change_type, cluster_id):

--- a/models/uri_drain/uri_drain.py
+++ b/models/uri_drain/uri_drain.py
@@ -524,7 +524,7 @@ class Drain(DrainBase):
 
     def check_all_url_deep_correct(self, text):
         words = self.split_for_url(text)
-        # if the word is a number, then it's not a param
+        # if the word is a number, then it's maybe a param
         if len(words) == 1 and words[0].isdigit():
             return False
         for word in self.split_for_url(text):

--- a/models/uri_drain/uri_drain.py
+++ b/models/uri_drain/uri_drain.py
@@ -524,10 +524,10 @@ class Drain(DrainBase):
 
     def check_all_url_deep_correct(self, text):
         words = self.split_for_url(text)
-        # if the word is a number, then it's maybe a param
-        if len(words) == 1 and words[0].isdigit():
-            return False
         for word in self.split_for_url(text):
+            # if contains digits, then it's not a word, ignore the word check
+            if word.isdigit():
+                return False
             # When a word is not corrected, then it's not a param
             # text blob would also split the world by regex `\w+`, so no worry about special characters(such as "_", ".")
             corrected_word = TextBlob(word).correct()
@@ -542,14 +542,6 @@ class Drain(DrainBase):
         ret_val = list(seq2)
         seq_length = len(seq1)
 
-        # SPECIAL ASSUMPTION THAT MIGHT BE FALSE::
-        # /api/getconnection
-        # /api/dropconnection
-        if seq_length == 2:
-            if (seq1[0] == seq2[0] and seq1[1] != seq2[1]  # can be simplified
-                    and not self.has_numbers(seq1[1]) and not self.has_numbers(seq2[1])):
-                print(f'first token match but second token mismatch, seq1 = {seq1}, seq2 = {seq2}')
-                return 'rejected'
         # TODO, radical assumption if there's absolutely 0 digit in seq1 and seq2, then don't consider them similar?
         # To implement this, we increase the false negative rate, but decrease false positive rate
 

--- a/models/uri_drain/uri_drain.py
+++ b/models/uri_drain/uri_drain.py
@@ -11,8 +11,6 @@ from cachetools import LRUCache, Cache
 from models.uri_drain.word_splitter import check_all_word_correct
 from models.utils.simple_profiler import Profiler, NullProfiler
 
-from textblob import TextBlob
-
 import logger
 
 

--- a/models/uri_drain/word_splitter.py
+++ b/models/uri_drain/word_splitter.py
@@ -1,0 +1,52 @@
+# Copyright 2023 SkyAPM org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+from cachetools import LRUCache, Cache
+from textblob import TextBlob
+
+last_word_correct_lru = LRUCache(1000)
+
+
+def split_for_url(text):
+    # split text by camel case
+    pattern = r"(?<=[a-z])(?=[A-Z])"
+    return re.split(pattern, text)
+
+
+def check_all_word_correct(text):
+    # if contains digits, then it's not a word, ignore the word check
+    if any(char.isdigit() for char in text):
+        return False
+    for word in split_for_url(text):
+        # if a word is too long, then it's not a word, just ignore to verify to reduce the analysis time
+        if len(word) > 20:
+            return False
+        word = word.lower()
+        cached_result = last_word_correct_lru.get(word)
+        if cached_result is not None:
+            if cached_result:
+                continue
+            else:
+                return False
+        # When a word is not corrected, then it's not a param
+        # text blob would also split the world by regex `\w+`, so no worry about special characters(such as "_", ".")
+        corrected_word = TextBlob(word).correct()
+        correct = word == corrected_word
+        last_word_correct_lru[word] = correct
+        if not correct:
+            return False
+
+    return True

--- a/models/uri_drain/word_splitter.py
+++ b/models/uri_drain/word_splitter.py
@@ -14,7 +14,7 @@
 
 import re
 
-from cachetools import LRUCache, Cache
+from cachetools import LRUCache
 from textblob import TextBlob
 
 last_word_correct_lru = LRUCache(1000)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1144,13 +1144,13 @@ files = [
 
 [[package]]
 name = "jsonpickle"
-version = "3.2.2"
+version = "3.3.0"
 description = "Python library for serializing arbitrary object graphs into JSON"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jsonpickle-3.2.2-py3-none-any.whl", hash = "sha256:87cd82d237fd72c5a34970e7222dddc0accc13fddf49af84111887ed9a9445aa"},
-    {file = "jsonpickle-3.2.2.tar.gz", hash = "sha256:d425fd2b8afe9f5d7d57205153403fbf897782204437882a477e8eed60930f8c"},
+    {file = "jsonpickle-3.3.0-py3-none-any.whl", hash = "sha256:287c12143f35571ab00e224fa323aa4b090d5a7f086f5f494d7ee9c7eb1a380a"},
+    {file = "jsonpickle-3.3.0.tar.gz", hash = "sha256:ab467e601e5b1a1cd76f1819d014795165da071744ef30bf3786e9bc549de25a"},
 ]
 
 [package.extras]
@@ -1505,13 +1505,13 @@ files = [
 
 [[package]]
 name = "narwhals"
-version = "1.6.0"
+version = "1.6.1"
 description = "Extremely lightweight compatibility layer between dataframe libraries"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "narwhals-1.6.0-py3-none-any.whl", hash = "sha256:4ec5b248998ae552491bc1f497448e94f0f539f5664428a31ddf662c5d46c244"},
-    {file = "narwhals-1.6.0.tar.gz", hash = "sha256:0b0d12f994ac7832c70af29241c32a4f7afddc1cf669f40f6318533d52204595"},
+    {file = "narwhals-1.6.1-py3-none-any.whl", hash = "sha256:5dd0dd3691dbc5b44567d6dcb7506a099523ef70cd024d0e6e34af6284eed02b"},
+    {file = "narwhals-1.6.1.tar.gz", hash = "sha256:c618e451a77ade63beccd55ddbe64434f14f939cd1672d3d1156c20c1e1642ff"},
 ]
 
 [package.extras]
@@ -2511,13 +2511,13 @@ doc = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "setuptools"
-version = "74.0.0"
+version = "74.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-74.0.0-py3-none-any.whl", hash = "sha256:0274581a0037b638b9fc1c6883cc71c0210865aaa76073f7882376b641b84e8f"},
-    {file = "setuptools-74.0.0.tar.gz", hash = "sha256:a85e96b8be2b906f3e3e789adec6a9323abf79758ecfa3065bd740d81158b11e"},
+    {file = "setuptools-74.1.0-py3-none-any.whl", hash = "sha256:cee604bd76cc092355a4e43ec17aee5369095974f41f088676724dc6bc2c9ef8"},
+    {file = "setuptools-74.1.0.tar.gz", hash = "sha256:bea195a800f510ba3a2bc65645c88b7e016fe36709fefc58a880c4ae8a0138d7"},
 ]
 
 [package.extras]
@@ -2564,13 +2564,13 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.38.3"
+version = "0.38.4"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "starlette-0.38.3-py3-none-any.whl", hash = "sha256:0e4af343a4e59324b96fbe0f3c6ad8c3a908d73f12f5c80a797803a6c3ad4687"},
-    {file = "starlette-0.38.3.tar.gz", hash = "sha256:f674450f0f46a790be1f3a128f386080600b58fa358f8e320d93dbef6d7f676c"},
+    {file = "starlette-0.38.4-py3-none-any.whl", hash = "sha256:526f53a77f0e43b85f583438aee1a940fd84f8fd610353e8b0c1a77ad8a87e76"},
+    {file = "starlette-0.38.4.tar.gz", hash = "sha256:53a7439060304a208fea17ed407e998f46da5e5d9b1addfea3040094512a6379"},
 ]
 
 [package.dependencies]
@@ -2579,6 +2579,25 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 
 [package.extras]
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
+
+[[package]]
+name = "textblob"
+version = "0.18.0"
+description = "Simple, Pythonic text processing. Sentiment analysis, part-of-speech tagging, noun phrase parsing, and more."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "textblob-0.18.0-py3-none-any.whl", hash = "sha256:eb29995ab2a9acc2e0fde10dde6b069b01193c75f3dfc2550d0d1ffdd97802bf"},
+    {file = "textblob-0.18.0.tar.gz", hash = "sha256:eb507b62bf2283a71f56bed3e0fc4eec7d388ef76b03699cf994166572a8daf3"},
+]
+
+[package.dependencies]
+nltk = ">=3.8"
+
+[package.extras]
+dev = ["pre-commit (>=3.5,<4.0)", "textblob[tests]", "tox"]
+docs = ["PyYAML (==6.0.1)", "sphinx (==7.2.6)", "sphinx-issues (==4.0.0)"]
+tests = ["numpy", "pytest"]
 
 [[package]]
 name = "tomli"
@@ -2889,4 +2908,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "e43f94f67c34ccdc1232bc2e63ef4b4fde01d8b2c9cd51e85dfa4b80a347ce99"
+content-hash = "213599d8152e698f5954913ab45f8c084513920aba9672da65a980053d93a4e2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ inflect = "^6.0.4"
 pytest = "^7.3.2"
 apache-skywalking = "^1.0.1"
 flask = "^2.3.2"
+textblob = "0.18.0"
 
 
 

--- a/servers/simple/uri_drain.ini
+++ b/servers/simple/uri_drain.ini
@@ -35,7 +35,7 @@ max_children = ${DRAIN_MAX_CHILDREN:100}
 max_clusters = ${DRAIN_MAX_CLUSTERS:1024}
 extra_delimiters = ${DRAIN_EXTRA_DELIMITERS:["/"]}
 analysis_min_url_count = ${DRAIN_ANALYSIS_MIN_URL_COUNT:20}
-combine_min_url_count = ${DRAIN_COMBINE_MIN_URL_COUNT:8}
+combine_min_url_count = ${DRAIN_COMBINE_MIN_URL_COUNT:3}
 
 [PROFILING]
 enabled = ${PROFILING_ENABLED:False}

--- a/servers/simple/worker.py
+++ b/servers/simple/worker.py
@@ -50,7 +50,8 @@ def run_worker(uri_main_queue, shared_results_object, config, existing_miners):
             uris, service = uri_package[0], uri_package[1]
             # print(uri_main_queue.get(timeout=1))
             start_time = time.time()
-            for uri in uris:
+            sorted_uris = sorted(uris)
+            for uri in sorted_uris:
                 drain_instances[service].add_log_message(uri)
             logger.info(f'Processed {len(uris)} uris of service {service} in {time.time() - start_time} seconds')
             patterns = drain_instances[service].drain.cluster_patterns

--- a/test/e2e/expected/endpoint_hard.yaml
+++ b/test/e2e/expected/endpoint_hard.yaml
@@ -19,8 +19,13 @@ patterns:
     - /api/v1/services/{var}
     - /api/v1/users/{var}/posts/{var}/comments
     - /api/v1/wallets/{var}
+    - /api/v2/admin/users/{var}
     - /api/v2/courses/{var}/modules/{var}/lessons
     - /api/v2/customers/{var}
     - /api/v3/products/{var}/reviews/{var}/comments
     - /api/v4/orders/{var}/items/{var}/tracking
+    - /customer/{var}
+    - /customer/{var}/order/{var}
+    - ABC/{var}
+    - www.google.com/api/v1/users/{var}
 version: '1'

--- a/test/e2e/expected/endpoint_hard_3k.yaml
+++ b/test/e2e/expected/endpoint_hard_3k.yaml
@@ -19,8 +19,12 @@ patterns:
     - /api/v1/services/{var}
     - /api/v1/users/{var}/posts/{var}/comments
     - /api/v1/wallets/{var}
+    - /api/v2/admin/users/{var}
     - /api/v2/courses/{var}/modules/{var}/lessons
     - /api/v2/customers/{var}
     - /api/v3/products/{var}/reviews/{var}/comments
     - /api/v4/orders/{var}/items/{var}/tracking
+    - /customer/{var}
+    - /customer/{var}/order/{var}
+    - www.google.com/api/v1/users/{var}
 version: '1'

--- a/test/e2e/expected/endpoint_trivial.yaml
+++ b/test/e2e/expected/endpoint_trivial.yaml
@@ -14,8 +14,13 @@
 
 patterns:
     - /api/v1/accounts/{var}
+    - /api/v1/invoices/{var}
     - /api/v1/orders/{var}
     - /api/v1/posts/{var}
     - /api/v1/products/{var}
     - /api/v1/users/{var}
+    - /api/v2/data/users/{var}
+    - /api/v999/orders/{var}
+    - /user/{var}/post/{var}
+    - /user/{var}/profile/{var}/compare/{var}/profile/{var}
 version: '1'

--- a/test/e2e/expected/endpoint_trivial_3k.yaml
+++ b/test/e2e/expected/endpoint_trivial_3k.yaml
@@ -19,4 +19,9 @@ patterns:
     - /api/v1/posts/{var}
     - /api/v1/products/{var}
     - /api/v1/users/{var}
+    - /api/v2/data/users/{var}
+    - /api/v999/orders/{var}
+    - /user/{var}
+    - /user/{var}/post/{var}
+    - /user/{var}/profile/{var}/compare/{var}/profile/{var}
 version: '1'


### PR DESCRIPTION
If the pattern contains words, then we should not combine them as a variable path. 
For example, there are three URLs `/test/t/one`, `test/t/two/`, and `test/t/three`. In the old way, they will combine to `/test/t/{var}`, After we add `textblob` and word spitter, the result will keep the original URL list. 

The Basic logic is: 
1. Split the word in each URL step by camel and digits.
2. Use the [textblob](https://textblob.readthedocs.io/) framework to analyze whether the word is correct or not, If the word is correct, then the URL will not merge into the existing pattern, otherwise, keep the original logical. 

Finally, we can reduce the `DRAIN_COMBINE_MIN_URL_COUNT` environment to reduce the count of combined URL logic. 