### PR TITLE
cves: fix openssl, glibc CVEs via package upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ ENV PYTHONUNBUFFERED=1
 
 # Upgrade OS packages to pick up security patches:
 # CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (glibc), CVE-2026-2219 (dpkg), CVE-2025-7709 (libsqlite3)
+# CVE-2026-28389, CVE-2026-31789, CVE-2026-28390, CVE-2026-31790, CVE-2026-2673 (openssl 3.5.5-1~deb13u2)
+# CVE-2025-15281 (glibc 2.41-12+deb13u2)
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

This PR triggers a rebuild of the oapr3 Docker image to pick up the latest Debian security patches that became available after the previous build.

The Dockerfile already contains `apt-get update && apt-get upgrade -y`, but the image built at `87296a3` (2026-03-30) predates the following Debian security fixes:

- **openssl 3.5.5-1~deb13u2** (released to Debian trixie on 2026-04-07/08 via DSA-6201-1)
- **glibc 2.41-12+deb13u2** (released to Debian trixie)

## CVEs Fixed

| Severity | CVE ID | Package | Fixed Version |
|----------|--------|---------|---------------|
| HIGH | CVE-2026-28390 | openssl | 3.5.5-1~deb13u2 |
| MEDIUM | CVE-2026-31790 | openssl | 3.5.5-1~deb13u2 |
| LOW | CVE-2026-28389 | openssl | 3.5.5-1~deb13u2 |
| LOW | CVE-2026-31789 | openssl | 3.5.5-1~deb13u2 |
| LOW | CVE-2026-2673 | openssl | 3.5.5-1~deb13u2 |
| MEDIUM | CVE-2025-15281 | glibc | 2.41-12+deb13u2 |

## Change

Updated the Dockerfile comment to document the new CVEs addressed by the rebuild. The `apt-get upgrade` command is already in place and will automatically pick up the fixed packages during the new build.

Closes https://github.com/tetrateio/tetrate/issues/28332
Closes https://github.com/tetrateio/tetrate/issues/28339
Closes https://github.com/tetrateio/tetrate/issues/28364
Closes https://github.com/tetrateio/tetrate/issues/28381
Closes https://github.com/tetrateio/tetrate/issues/28352
Closes https://github.com/tetrateio/tetrate/issues/28382