### PR TITLE
cves: bump grpcio-tools to 1.80.0, document openssl/xz-utils CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV PYTHONUNBUFFERED=1
 # Upgrade OS packages to pick up security patches:
 # CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (glibc), CVE-2026-2219 (dpkg), CVE-2025-7709 (libsqlite3)
 # CVE-2026-40226, CVE-2026-40228 (systemd), CVE-2026-27456 (util-linux), CVE-2025-6141 (ncurses), CVE-2026-5704 (tar)
+# CVE-2026-2673, CVE-2026-28387, CVE-2026-28388 (openssl 3.5.5-1~deb13u2), CVE-2026-34743 (xz-utils 5.8.3)
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -29,7 +30,7 @@ COPY . /app
 
 # Build the project with make
 RUN python3 -m pip install -U pip \
-  && python3 -m pip install grpcio-tools==1.68.0 packaging \
+  && python3 -m pip install grpcio-tools==1.80.0 packaging \
 	&& python3 -m tools.grpc_gen \
   && python3 -m pip install .[all]
 


### PR DESCRIPTION
## Summary

This PR fixes CVEs in the oapr3 Docker image by:

1. **Bumping grpcio-tools from 1.68.0 to 1.80.0** in the Dockerfile — this replaces the transitive dependency protobuf 5.29.6 with protobuf 6.33.6, fixing CVE-2026-0994 (HIGH).
2. **Documenting openssl CVEs** — the existing `apt-get upgrade` in the Dockerfile already installs openssl 3.5.5-1~deb13u2 from `trixie-security`, fixing CVE-2026-2673, CVE-2026-28387, and CVE-2026-28388.
3. **Noting CVE-2026-34743 (xz-utils)** — fixed version 5.8.3 is not yet available in Debian Trixie repositories; will be resolved when Debian publishes the patched package.

## CVEs Fixed

| CVE ID | Severity | Package | Old Version | Fixed Version | Fix |
|--------|----------|---------|-------------|---------------|-----|
| CVE-2026-0994 | HIGH | protobuf | 5.29.6 | 6.33.6 | Bump grpcio-tools to 1.80.0 in Dockerfile |
| CVE-2026-2673 | LOW | openssl/libssl3t64 | 3.5.5-1~deb13u1 | 3.5.5-1~deb13u2 | apt-get upgrade (trixie-security) |
| CVE-2026-28387 | LOW | openssl/libssl3t64 | 3.5.5-1~deb13u1 | 3.5.5-1~deb13u2 | apt-get upgrade (trixie-security) |
| CVE-2026-28388 | HIGH | openssl/libssl3t64 | 3.5.5-1~deb13u1 | 3.5.5-1~deb13u2 | apt-get upgrade (trixie-security) |
| CVE-2026-34743 | MEDIUM | xz-utils/liblzma5 | 5.8.1-1 | 5.8.3 (pending) | Not yet available in Debian repos |

Note: CVE-2025-71176 (pytest 9.0.2 → 9.0.3) was already fixed in a previous commit (0ecb13c).

## Scan Results

Locally built image verified with trivy:
- CVE-2026-0994 (protobuf): **ABSENT** (protobuf 6.33.6 installed)
- CVE-2026-2673 (openssl): **ABSENT** (openssl 3.5.5-1~deb13u2 installed)
- CVE-2026-28387 (openssl): **ABSENT** (openssl 3.5.5-1~deb13u2 installed)
- CVE-2026-28388 (openssl): **ABSENT** (openssl 3.5.5-1~deb13u2 installed)
- CVE-2026-34743 (xz-utils): **PRESENT** (fixed version not in Debian repos yet)

## Related Issues

Related to tetrateio/tetrate#29381
Related to tetrateio/tetrate#29396
Related to tetrateio/tetrate#29399
Related to tetrateio/tetrate#29414
Related to tetrateio/tetrate#29430
Related to tetrateio/tetrate#29435

@kezhenxu94 Please review when you get a chance.