### PR TITLE
cves: upgrade pip to >=26.1 to fix CVE-2026-6357

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ WORKDIR /app
 COPY . /app
 
 # Build the project with make
-RUN python3 -m pip install -U pip \
+# Upgrade pip to >=26.1 to fix CVE-2026-6357
+RUN python3 -m pip install "pip>=26.1" \
   && python3 -m pip install grpcio-tools==1.80.0 packaging \
 	&& python3 -m tools.grpc_gen \
   && python3 -m pip install .[all]


### PR DESCRIPTION
## Summary

This PR fixes CVE-2026-6357 by explicitly requiring pip>=26.1 in the Dockerfile.

## CVEs Fixed

| CVE ID | Severity | Package | Fix |
|--------|----------|---------|-----|
| CVE-2026-6357 | MEDIUM | pip 26.0.1 | Upgraded to pip>=26.1 (installs 26.1.1) |

## Changes

The Dockerfile previously used `pip install -U pip` (upgrade to latest) which at the time of building the `0ecb13c` and `87296a3` image tags resulted in pip 26.0.1 being installed (vulnerable). Now that pip 26.1+ is available on PyPI, the Dockerfile is updated to explicitly require `pip>=26.1` to document and enforce the minimum safe version.

**Before:**
```
RUN python3 -m pip install -U pip \
```

**After:**
```
# Upgrade pip to >=26.1 to fix CVE-2026-6357
RUN python3 -m pip install "pip>=26.1" \
```

The fix was verified locally by building the Docker image and running a Trivy scan — CVE-2026-6357 is absent in the updated image (pip 26.1.1 installed).

## Related Issues

Related to tetrateio/tetrate#29951
Related to tetrateio/tetrate#29998