### PR TITLE
cves: upgrade OS packages to fix libcap2, glibc, systemd CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ENV PYTHONUNBUFFERED=1
 # CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (glibc), CVE-2026-2219 (dpkg), CVE-2025-7709 (libsqlite3)
 # CVE-2026-40226, CVE-2026-40228 (systemd), CVE-2026-27456 (util-linux), CVE-2025-6141 (ncurses), CVE-2026-5704 (tar)
 # CVE-2026-2673, CVE-2026-28387, CVE-2026-28388 (openssl 3.5.5-1~deb13u2), CVE-2026-34743 (xz-utils 5.8.3)
+# CVE-2026-4878 (libcap2 >=1:2.75-10+deb13u1), CVE-2026-4046, CVE-2026-4437 (glibc >=2.41-12+deb13u3)
+# CVE-2026-29111 (systemd >=257.13-1~deb13u1)
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

Upgrades OS packages in the Docker image to fix the following CVEs by
running `apt-get update && apt-get upgrade -y` (already present in the
Dockerfile) against the latest Debian package repositories.

| CVE | Severity | Package | Fixed Version |
|-----|----------|---------|---------------|
| CVE-2026-4878 | HIGH | libcap2 | ≥ 1:2.75-10+deb13u1 |
| CVE-2026-4046 | HIGH | glibc, libc6, libc-bin | ≥ 2.41-12+deb13u3 |
| CVE-2026-4437 | MEDIUM | glibc, libc6, libc-bin | ≥ 2.41-12+deb13u3 |
| CVE-2026-29111 | LOW | systemd, libudev1, libsystemd0 | ≥ 257.13-1~deb13u1 |

## Verification

Trivy scan of locally built image (`ghcr.io/skyapm/r3:579f664`) confirms all four targeted CVEs are **absent**.

Related to tetrateio/tetrate#30417
Related to tetrateio/tetrate#30418
Related to tetrateio/tetrate#30420
Related to tetrateio/tetrate#30421
Related to tetrateio/tetrate#30424
Related to tetrateio/tetrate#30425
Related to tetrateio/tetrate#30427

@kezhenxu94