### PR TITLE
cves: bump pip to >=26.1.2 to fix CVE-2026-8643

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ WORKDIR /app
 COPY . /app
 
 # Build the project with make
-# Upgrade pip to >=26.1 to fix CVE-2026-6357
-RUN python3 -m pip install "pip>=26.1" \
+# Upgrade pip to >=26.1.2 to fix CVE-2026-6357, CVE-2026-8643
+RUN python3 -m pip install "pip>=26.1.2" \
   && python3 -m pip install grpcio-tools==1.80.0 packaging \
 	&& python3 -m tools.grpc_gen \
   && python3 -m pip install .[all]


### PR DESCRIPTION
## Summary

Bump pip minimum version from `>=26.1` to `>=26.1.2` to fix CVE-2026-8643.

| CVE ID | Severity | Package | Fix |
|--------|----------|---------|-----|
| CVE-2026-8643 | Medium | pip | Upgraded from 26.1.1 to >=26.1.2 |

Related to tetrateio/tetrate#30743
Related to tetrateio/tetrate#30745
Related to tetrateio/tetrate#30747