### PR TITLE
cves: bump setuptools to >=80.10.2 and click to >=8.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,12 @@ COPY . /app
 
 # Build the project with make
 # Upgrade pip to >=26.1.2 to fix CVE-2026-6357, CVE-2026-8643
-RUN python3 -m pip install "pip>=26.1.2" \
+# Upgrade setuptools to >=80.10.2 to fix CVE-2026-23949, CVE-2026-24049
+# Upgrade click to >=8.3.3 to fix CVE-2026-7246
+RUN python3 -m pip install "pip>=26.1.2" "setuptools>=80.10.2" \
   && python3 -m pip install grpcio-tools==1.80.0 packaging \
 	&& python3 -m tools.grpc_gen \
-  && python3 -m pip install .[all]
+  && python3 -m pip install .[all] "click>=8.3.3"
 
 # Expose the gRPC service port
 EXPOSE 17128


### PR DESCRIPTION
Fixes python-dependency CVEs reported by JFrog Xray against the oapr3 image:

| Package | CVE | Severity | Fixed in |
|---|---|---|---|
| setuptools | CVE-2026-23949 | High | 80.10.0 |
| setuptools | CVE-2026-24049 | Medium | 80.10.2 |
| click | CVE-2026-7246 | High | 8.3.3 |

Follows the same Dockerfile pattern as the earlier pip bump (#213).

Verified by building the image locally and rescanning: the scan went from 280 findings (old published image) to 106, with all three CVEs above gone. The remaining findings are debian-trixie base packages with no fixed versions released yet (libc6, perl-base, pam, ncurses) and the ancient disputed pip CVE-2018-20225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)