### PR TITLE
cves: upgrade openssl packages to fix CVE-2026-34183, CVE-2026-42769, CVE-2026-34181, CVE-2026-42768

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,10 @@ ENV PYTHONUNBUFFERED=1
 # CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (glibc), CVE-2026-2219 (dpkg), CVE-2025-7709 (libsqlite3)
 # CVE-2026-40226, CVE-2026-40228 (systemd), CVE-2026-27456 (util-linux), CVE-2025-6141 (ncurses), CVE-2026-5704 (tar)
 # CVE-2026-2673, CVE-2026-28387, CVE-2026-28388 (openssl 3.5.5-1~deb13u2), CVE-2026-34743 (xz-utils 5.8.3)
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+# CVE-2026-34183, CVE-2026-42769, CVE-2026-34181, CVE-2026-42768 (openssl 3.5.6-1~deb13u2)
+RUN apt-get update && apt-get upgrade -y \
+    openssl libssl3t64 openssl-provider-legacy \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## CVEs Fixed

| CVE | Severity | Package | Fix |
|-----|----------|---------|-----|
| CVE-2026-34183 | MEDIUM | openssl, libssl3t64, openssl-provider-legacy | Explicit apt-get upgrade to 3.5.6-1~deb13u2 |
| CVE-2026-42769 | LOW | openssl, libssl3t64, openssl-provider-legacy | Explicit apt-get upgrade to 3.5.6-1~deb13u2 |
| CVE-2026-34181 | LOW | openssl, libssl3t64, openssl-provider-legacy | Explicit apt-get upgrade to 3.5.6-1~deb13u2 |
| CVE-2026-42768 | LOW | openssl, libssl3t64, openssl-provider-legacy | Explicit apt-get upgrade to 3.5.6-1~deb13u2 |

Explicitly adds openssl-related packages to the apt-get upgrade command to ensure they are upgraded to patched versions (Debian 3.5.5-1~deb13u2 → 3.5.6-1~deb13u2).

/cc @kezhenxu94