### PR TITLE
cves: bump pip to 26.2 to fix CVE-2026-13346

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,10 @@ WORKDIR /app
 COPY . /app
 
 # Build the project with make
-# Upgrade pip to >=26.1.2 to fix CVE-2026-6357, CVE-2026-8643
+# Upgrade pip to >=26.2 to fix CVE-2026-6357, CVE-2026-8643, CVE-2026-13346
 # Upgrade setuptools to >=83.0.0 to fix CVE-2026-23949, CVE-2026-24049, CVE-2026-59890
 # Upgrade click to >=8.3.3 to fix CVE-2026-7246
-RUN python3 -m pip install "pip>=26.1.2" "setuptools>=83.0.0" \
+RUN python3 -m pip install "pip>=26.2" "setuptools>=83.0.0" \
   && python3 -m pip install grpcio-tools==1.80.0 packaging \
 	&& python3 -m tools.grpc_gen \
   && python3 -m pip install .[all] "click>=8.3.3"


### PR DESCRIPTION
## Summary

Bumps pip from >=26.1.2 to >=26.2 to fix CVE-2026-13346.

| CVE ID | Severity | Package | Fix |
|--------|----------|---------|-----|
| CVE-2026-13346 | MEDIUM | pip | 26.1.2 → 26.2 |

Related to tetrateio/tetrate#33400
Related to tetrateio/tetrate#33402
Related to tetrateio/tetrate#33403

/cc @kezhenxu94