### PR TITLE
cves: bump msgpack to >=1.2.1 to fix CVE-2026-57585, GHSA-6v7p-g79w-8964

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,11 @@ COPY . /app
 # Upgrade pip to >=26.2 to fix CVE-2026-6357, CVE-2026-8643, CVE-2026-13346
 # Upgrade setuptools to >=83.0.0 to fix CVE-2026-23949, CVE-2026-24049, CVE-2026-59890
 # Upgrade click to >=8.3.3 to fix CVE-2026-7246
+# Upgrade msgpack to >=1.2.1 to fix CVE-2026-57585, GHSA-6v7p-g79w-8964
 RUN python3 -m pip install "pip>=26.2" "setuptools>=83.0.0" \
   && python3 -m pip install grpcio-tools==1.80.0 packaging \
 	&& python3 -m tools.grpc_gen \
-  && python3 -m pip install .[all] "click>=8.3.3"
+  && python3 -m pip install .[all] "click>=8.3.3" "msgpack>=1.2.1"
 
 # Expose the gRPC service port
 EXPOSE 17128


### PR DESCRIPTION
## Summary

This PR upgrades `msgpack` to `>=1.2.1` to fix two security vulnerabilities:

| CVE | Severity | Package | Fixed Version |
|-----|----------|---------|---------------|
| CVE-2026-57585 | HIGH | msgpack | 1.2.1 |
| GHSA-6v7p-g79w-8964 | HIGH | msgpack | 1.2.1 |

The `msgpack` package is a transitive runtime dependency. The fix pins it to `>=1.2.1` in the Dockerfile's pip install command.

Also related to fixes already present in this branch:
- pip `>=26.2` (CVE-2026-13346, CVE-2026-6357, CVE-2026-8643)
- setuptools `>=83.0.0` (CVE-2026-23949, CVE-2026-24049, CVE-2026-59890)

Related to tetrateio/tetrate#33597
Related to tetrateio/tetrate#33598
Related to tetrateio/tetrate#33592
Related to tetrateio/tetrate#33593
Related to tetrateio/tetrate#33594
Related to tetrateio/tetrate#33596

@kezhenxu94 Could you please review and merge?