### PR TITLE
cves: upgrade util-linux family to 2.41.5-0+deb13u1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,17 @@ ENV PYTHONUNBUFFERED=1
 
 # Upgrade OS packages to pick up security patches:
 # CVE-2025-15281, CVE-2026-0861, CVE-2026-0915 (glibc), CVE-2026-2219 (dpkg), CVE-2025-7709 (libsqlite3)
-# CVE-2026-40226, CVE-2026-40228 (systemd), CVE-2026-27456 (util-linux), CVE-2025-6141 (ncurses), CVE-2026-5704 (tar)
+# CVE-2026-40226, CVE-2026-40228 (systemd), CVE-2025-6141 (ncurses), CVE-2026-5704 (tar)
 # CVE-2026-2673, CVE-2026-28387, CVE-2026-28388 (openssl 3.5.5-1~deb13u2)
 # CVE-2026-34183, CVE-2026-42769, CVE-2026-34181, CVE-2026-42768 (openssl 3.5.6-1~deb13u2)
 # CVE-2026-34743 (xz-utils/liblzma5 5.8.1-1+deb13u1)
+# CVE-2026-13595, CVE-2026-27456, CVE-2026-53612, CVE-2026-53613, CVE-2026-53614,
+# CVE-2026-53615 (util-linux family 2.41.5-0+deb13u1)
 # NOTE: `apt-get upgrade` only upgrades the packages explicitly named below, so every
 # package that carries a security fix must be listed here.
 RUN apt-get update && apt-get upgrade -y \
     openssl libssl3t64 openssl-provider-legacy liblzma5 \
+    util-linux bsdutils libblkid1 liblastlog2-2 libmount1 libsmartcols1 libuuid1 login mount \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
The `python:3.13-slim` base image still ships `util-linux` 2.41-5, which carries
several vulnerabilities fixed in Debian 13's `2.41.5-0+deb13u1`. Since the
`apt-get upgrade` in the Dockerfile only upgrades the packages named explicitly,
all nine binary packages built from the `util-linux` source package are added to
the list.

### CVEs fixed

| CVE | Severity | Package | Fixed by |
|---|---|---|---|
| CVE-2026-13595 | high | util-linux 2.41-5 | util-linux family -> 2.41.5-0+deb13u1 |
| CVE-2026-27456 | high | util-linux 2.41-5 | util-linux family -> 2.41.5-0+deb13u1 |
| CVE-2026-53612 | medium | util-linux 2.41-5 | util-linux family -> 2.41.5-0+deb13u1 |
| CVE-2026-53613 | medium | util-linux 2.41-5 | util-linux family -> 2.41.5-0+deb13u1 |
| CVE-2026-53614 | medium | util-linux 2.41-5 | util-linux family -> 2.41.5-0+deb13u1 |
| CVE-2026-53615 | medium | util-linux 2.41-5 | util-linux family -> 2.41.5-0+deb13u1 |

Packages upgraded: `util-linux`, `bsdutils`, `libblkid1`, `liblastlog2-2`,
`libmount1`, `libsmartcols1`, `libuuid1`, `login`, `mount`.

### Verification

Locally built image, all nine packages at `2.41.5-0+deb13u1` (`login` at
`1:4.16.0-2+really2.41.5-0+deb13u1`), and a Prisma/twistcli scan of the built
image reports none of the six CVEs above. The only remaining `util-linux`
finding is CVE-2026-3184, which has no fix available in Debian yet.

/cc @kezhenxu94
