### PR TITLE
cves: bump openssl to 3.5.7, nltk to 3.10.3, util-linux to 2.41.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,12 @@ ENV PYTHONUNBUFFERED=1
 # CVE-2026-40226, CVE-2026-40228 (systemd), CVE-2025-6141 (ncurses), CVE-2026-5704 (tar)
 # CVE-2026-2673, CVE-2026-28387, CVE-2026-28388 (openssl 3.5.5-1~deb13u2)
 # CVE-2026-34183, CVE-2026-42769, CVE-2026-34181, CVE-2026-42768 (openssl 3.5.6-1~deb13u2)
+# CVE-2026-63073, CVE-2026-63076, CVE-2026-63072, CVE-2026-54874, CVE-2026-63074,
+# CVE-2026-14456, CVE-2026-63075, CVE-2026-56864, CVE-2026-75803 (openssl 3.5.7-1~deb13u2)
 # CVE-2026-34743 (xz-utils/liblzma5 5.8.1-1+deb13u1)
 # CVE-2026-13595, CVE-2026-27456, CVE-2026-53612, CVE-2026-53613, CVE-2026-53614,
 # CVE-2026-53615 (util-linux family 2.41.5-0+deb13u1)
+# CVE-2025-14104 (util-linux 2.41.3-1, already satisfied by 2.41.5-0+deb13u1)
 # NOTE: `apt-get upgrade` only upgrades the packages explicitly named below, so every
 # package that carries a security fix must be listed here.
 RUN apt-get update && apt-get upgrade -y \


### PR DESCRIPTION
## Summary

This PR fixes multiple CVEs across OS packages and Python dependencies:

### CVEs Fixed

| CVE ID | Severity | Package | Fix |
|--------|----------|---------|-----|
| CVE-2026-63073 | - | openssl | apt upgrade to 3.5.7-1~deb13u2 |
| CVE-2026-63076 | - | openssl | apt upgrade to 3.5.7-1~deb13u2 |
| CVE-2026-63072 | - | openssl | apt upgrade to 3.5.7-1~deb13u2 |
| CVE-2026-54874 | - | openssl | apt upgrade to 3.5.7-1~deb13u2 |
| CVE-2026-63074 | - | openssl | apt upgrade to 3.5.7-1~deb13u2 |
| CVE-2026-14456 | - | openssl | apt upgrade to 3.5.7-1~deb13u2 |
| CVE-2026-63075 | - | openssl | apt upgrade to 3.5.7-1~deb13u2 |
| CVE-2026-56864 | - | openssl | apt upgrade to 3.5.7-1~deb13u2 |
| CVE-2026-75803 | - | openssl | apt upgrade to 3.5.7-1~deb13u2 |
| CVE-2025-14104 | - | util-linux | already satisfied by 2.41.5-0+deb13u1 |
| XRAY-1059810 | - | nltk | ^3.10.3 (3.10.3 already in lockfile) |
| CVE-2026-79676 | - | nltk | ^3.10.3 (3.10.3 already in lockfile) |
| XRAY-1059801 | - | nltk | ^3.10.3 (3.10.3 already in lockfile) |
| XRAY-1059803 | - | nltk | ^3.10.3 (3.10.3 already in lockfile) |
| XRAY-1059798 | - | nltk | ^3.10.3 (3.10.3 already in lockfile) |
| XRAY-1059806 | - | nltk | ^3.10.3 (3.10.3 already in lockfile) |
| CVE-2026-78680 | - | nltk | ^3.10.3 (3.10.3 already in lockfile) |
| CVE-2026-79674 | - | nltk | ^3.10.3 (3.10.3 already in lockfile) |
| CVE-2026-71513 | - | nltk | ^3.10.3 (3.10.3 already in lockfile) |

### Changes

- **Dockerfile**: Updated apt upgrade comment to document new openssl 3.5.7 CVEs and CVE-2025-14104 (util-linux). The `apt-get upgrade` already handles getting latest versions from Debian security repo.
- **pyproject.toml**: `nltk = "^3.10.3"` was already set; `poetry.lock` already pins nltk 3.10.3 which fixes the nltk CVEs.

The image was built locally and scanned with Trivy — none of the targeted CVEs appear in the scan output.

Related to tetrateio/tetrate#33967

@kezhenxu94